### PR TITLE
Concurrent place reservation

### DIFF
--- a/src/popo/place/place.dto.ts
+++ b/src/popo/place/place.dto.ts
@@ -8,6 +8,7 @@ export class PlaceDto {
   readonly region: PlaceRegion;
   readonly staff_email: string;
   readonly max_minutes: number;
+  readonly max_concurrent_reservation: number;
   readonly opening_hours: string;
   readonly enable_auto_accept: PlaceEnableAutoAccept;
 }

--- a/src/popo/place/place.entity.ts
+++ b/src/popo/place/place.entity.ts
@@ -36,6 +36,9 @@ export class Place extends BaseEntity {
   @Column({ default: 24 * 60 })
   max_minutes: number;
 
+  @Column({ default: 1 })
+  max_concurrent_reservation: number;
+
   @Column('text', { default: '{"Everyday":"00:00-24:00"}' })
   opening_hours: string;
   // if null, there's no rule for opening hours.

--- a/src/popo/reservation/equip/reserve.equip.controller.ts
+++ b/src/popo/reservation/equip/reserve.equip.controller.ts
@@ -148,7 +148,7 @@ export class ReserveEquipController {
     }
     return `Sync Done: ${equipmentList.length} Equipments`;
   }
-  
+
   @Get('count')
   count() {
     return this.reserveEquipService.count();
@@ -186,13 +186,10 @@ export class ReserveEquipController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   async patchStatus(
     @Param('uuid') uuid: string,
-    @Param('status') status: string,
+    @Param('status') status: ReservationStatus,
     @Query('sendEmail') sendEmail?: boolean,
   ) {
-    const response = await this.reserveEquipService.updateStatus(
-      uuid,
-      ReservationStatus[status],
-    );
+    const response = await this.reserveEquipService.updateStatus(uuid, status);
 
     if (sendEmail) {
       // Send e-mail to client.
@@ -201,7 +198,7 @@ export class ReserveEquipController {
         await this.mailService.sendReservationPatchMail(
           response.email,
           response.title,
-          ReservationStatus[status],
+          status,
         );
       }
     }

--- a/src/popo/reservation/place/reserve.place.service.ts
+++ b/src/popo/reservation/place/reserve.place.service.ts
@@ -29,6 +29,7 @@ export class ReservePlaceService {
     private readonly placeService: PlaceService,
   ) {}
 
+  // TODO: delete this code, after concurrent check logic is fully validated
   async isReservationOverlap(
     place_id: string,
     date: string,
@@ -131,6 +132,7 @@ export class ReservePlaceService {
 
     const targetPlace = await this.placeService.findOneByUuidOrFail(place_id);
 
+    // TODO: delete this code, after concurrent check logic is fully validated
     // Reservation Overlap Check
     // const isReservationOverlap = await this.isReservationOverlap(
     //   place_id,
@@ -148,7 +150,7 @@ export class ReservePlaceService {
     const isConcurrentPossible = await this.isReservationConcurrent(place_id, targetPlace.max_concurrent_reservation, date, start_time, end_time);
     if (!isConcurrentPossible) {
       throw new BadRequestException(
-        `"${targetPlace.name}" 장소에 이미 ${targetPlace.max_concurrent_reservation}개 예약이 있어 ${date} ${start_time} ~ ${end_time}에는 예약이 불가능 합니다.`
+        `"${targetPlace.name}" 장소에 이미 승인된 ${targetPlace.max_concurrent_reservation}개 예약이 있어 ${date} ${start_time} ~ ${end_time}에는 예약이 불가능 합니다.`
       )
     }
 

--- a/src/popo/reservation/place/reserve.place.service.ts
+++ b/src/popo/reservation/place/reserve.place.service.ts
@@ -145,13 +145,11 @@ export class ReservePlaceService {
     // }
 
     // Reservation Concurrent Check
-    if (targetPlace.max_concurrent_reservation > 1) {
-      const isConcurrentPossible = await this.isReservationConcurrent(place_id, targetPlace.max_concurrent_reservation, date, start_time, end_time);
-      if (!isConcurrentPossible) {
-        throw new BadRequestException(
-          `Place "${targetPlace.name}" can't be reserved on ${date} ${start_time} ~ ${end_time}, because there're ${targetPlace.max_concurrent_reservation} concurrent reservations for given range.`
-        )
-      }
+    const isConcurrentPossible = await this.isReservationConcurrent(place_id, targetPlace.max_concurrent_reservation, date, start_time, end_time);
+    if (!isConcurrentPossible) {
+      throw new BadRequestException(
+        `"${targetPlace.name}" 장소에 이미 ${targetPlace.max_concurrent_reservation}개 예약이 있어 ${date} ${start_time} ~ ${end_time}에는 예약이 불가능 합니다.`
+      )
     }
 
     // Reservation Duration Check

--- a/src/popo/reservation/place/reserve.place.service.ts
+++ b/src/popo/reservation/place/reserve.place.service.ts
@@ -162,7 +162,7 @@ export class ReservePlaceService {
       newReservationMinutes > targetPlace.max_minutes
     ) {
       throw new BadRequestException(
-        `${Message.OVER_MAX_RESERVATION_TIME}: max ${targetPlace.max_minutes} mins, new ${newReservationMinutes} mins`,
+        `${Message.OVER_MAX_RESERVATION_TIME}: "${targetPlace.name}" 장소는 하루 최대 ${targetPlace.max_minutes}분 동안 예약할 수 있습니다. 신규 예약은 ${newReservationMinutes}분으로 최대 예약 시간을 초과합니다.`,
       );
     }
 
@@ -173,7 +173,7 @@ export class ReservePlaceService {
       !(booker.userType === UserType.rc_student || booker.userType === UserType.admin)
     ) {
       throw new BadRequestException(
-        `This place is only available for RC students.`
+        `"${targetPlace.name}" 장소는 RC 학생만 예약할 수 있습니다.`
       )
     }
 
@@ -201,9 +201,9 @@ export class ReservePlaceService {
     ) {
       throw new BadRequestException(
         `${Message.OVER_MAX_RESERVATION_TIME}: `
-        + `최대 예약 가능 ${targetPlace.max_minutes}분 중에서 `
+        + `"${targetPlace.name}" 장소에 대해 하루 최대 예약 가능한 ${targetPlace.max_minutes}분 중에서 `
         + `오늘(${date}) ${totalReservationMinutes}분을 이미 예약했습니다. `
-        + `신규로 ${newReservationMinutes}분 예약하는 것은 불가능합니다.`,
+        + `신규로 ${newReservationMinutes}분을 예약하는 것은 불가능합니다.`,
       );
     }
   }


### PR DESCRIPTION
- 한 장소에서 동시 예약이 가능하도록 `max_concurrent_reservation` 컬럼 추가
- multiple reservation accept을 처리할 때 예약의 `created_at` 순서로 정렬 후 처리하도록 수정.