### PR TITLE
Add swagger plugin

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,4 +1,14 @@
 {
   "collection": "@nestjs/schematics",
-  "sourceRoot": "src"
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@nestjs/swagger",
+        "options": {
+          "classValidatorShim": true
+        }
+      }
+    ]
+  }
 }

--- a/src/popo/reservation/place/reserve.place.dto.ts
+++ b/src/popo/reservation/place/reserve.place.dto.ts
@@ -1,32 +1,21 @@
-import { ApiProperty } from '@nestjs/swagger';
-
 export class CreateReservePlaceDto {
-  @ApiProperty()
   readonly place_id: string; // uuid of place
 
-  @ApiProperty()
   readonly booker_id?: string; // uuid of booker
 
-  @ApiProperty()
   readonly phone: string;
 
-  @ApiProperty()
   readonly title: string;
 
-  @ApiProperty()
   readonly description: string;
 
-  @ApiProperty()
   readonly date: string; // YYYYMMDD
 
-  @ApiProperty()
   readonly start_time: string; // hhmm
 
-  @ApiProperty()
   readonly end_time: string; // hhmm
 }
 
 export class AcceptPlaceReservationListDto {
-  @ApiProperty()
   readonly uuid_list: string[];
 }


### PR DESCRIPTION
swagger 플러그인을 적용했습니다. 모든 dto, entity 파일에 간단한 swagger 기능이 자동으로 적용되어 따로 데코레이터를 붙이지 않아도 swagger 문서 상에서 DTO 형식 및 request, response의 json 형식 예시를 확인할 수 있습니다. 
`@IsInt` 같은 class-validator는 직접 추가해줘야 합니다.
아래는 해당 브랜치가 반영된 dev서버의 swagger 문서
![image](https://github.com/user-attachments/assets/a8769b2f-a13c-40f6-b00b-ca1d7bffcffe)
![image](https://github.com/user-attachments/assets/e541c8d0-a97f-4995-9cba-23fa97ce4701)
