### PR TITLE
Fix: Apply charset modification in serverside from utf8 to utf8mb4

### DIFF
--- a/src/config/configurations.ts
+++ b/src/config/configurations.ts
@@ -16,7 +16,7 @@ export default () => {
         : ['dist/**/*.entity.js'], // ✅ 프로덕션 환경에서는 컴파일된 JS 파일 포함
       synchronize: isTest ? true : process.env.DATABASE_SYNC === 'true', // 테스트 환경에서는 항상 true
       dropSchema: isTest, // ✅ 테스트 시 DB 초기화
-      charset: isTest ? undefined : 'utf8mb4',
+      charset: isTest ? undefined : 'utf8mb4', // 테스트 환경인 SQLite는 기본적으로 MYSQL의 utf8mb4까지 커버하므로 따로 설정 필요하지 않음
     },
   };
 };

--- a/src/config/configurations.ts
+++ b/src/config/configurations.ts
@@ -16,6 +16,7 @@ export default () => {
         : ['dist/**/*.entity.js'], // ✅ 프로덕션 환경에서는 컴파일된 JS 파일 포함
       synchronize: isTest ? true : process.env.DATABASE_SYNC === 'true', // 테스트 환경에서는 항상 true
       dropSchema: isTest, // ✅ 테스트 시 DB 초기화
+      charset: isTest ? undefined : 'utf8mb4',
     },
   };
 };


### PR DESCRIPTION
### 배경
DB의 기본 charset을 기존 utf8 -> utf8mb4(이모지 지원)로 일괄 변경함에 따라 서버측에도 이를 반영해야 합니다. typeorm 기본 charset 타입을 맞춰줬습니다.  

### 결과
변경 후 dev 서버의 API 콜을 통해 생활백서 테이블에 이모지를 넣을 수 있게 됨을 확인했습니다.

어드민 페이지에서 변경
<img width="978" alt="image" src="https://github.com/user-attachments/assets/06ec8dcb-d1de-41c9-a000-5db64fb7332d" />

dev 페이지에서 변경된 것 확인
<img width="1288" alt="image" src="https://github.com/user-attachments/assets/bb296fb2-fe39-4fda-aff9-e78003dccc26" />

dev DB
<img width="581" alt="image" src="https://github.com/user-attachments/assets/04b4dc2d-4cb2-41de-b919-0e91b26add93" />
