### PR TITLE
Feat: Put user nickname in cookie

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -32,8 +32,8 @@ export class AuthService {
 
     const encryptedPassword = this.encryptPassword(password, cryptoSalt);
     if (user.password === encryptedPassword) {
-      const { ...result } = user;
-      return result;
+      const nickname = await this.usersService.getNickname(user.uuid);
+      return { ...user, nickname: nickname.nickname };
     } else {
       return null;
     }
@@ -44,6 +44,7 @@ export class AuthService {
       uuid: user.uuid,
       email: user.email,
       name: user.name,
+      nickname: user.nickname,
       userType: user.userType,
     };
     return this.jwtService.sign(payload);

--- a/src/auth/strategies/jwt.payload.ts
+++ b/src/auth/strategies/jwt.payload.ts
@@ -3,6 +3,7 @@ import { UserType } from '../../popo/user/user.meta';
 export class JwtPayload {
   uuid: string;
   name: string;
+  nickname: string;
   userType: UserType;
   email: string;
 }

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -24,6 +24,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     return {
       uuid: payload.uuid,
       name: payload.name,
+      nickname: payload.nickname,
       userType: payload.userType,
       email: payload.email,
     };

--- a/src/popo/user/nickname.entity.ts
+++ b/src/popo/user/nickname.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { ApiHideProperty } from '@nestjs/swagger';
+import { Exclude } from 'class-transformer';
+
+import { User } from './user.entity';
+@Entity('nickname')
+export class Nickname {
+  @PrimaryGeneratedColumn()
+  @ApiHideProperty()
+  @Exclude()
+  id: number;
+
+  @Column({ type: 'uuid', nullable: false, unique: true })
+  userUuid: string;
+
+  @Column({ type: 'varchar', length: 20, nullable: false })
+  nickname: string;
+
+  @OneToOne(() => User, (user) => user.nickname, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'userUuid' })
+  @ApiHideProperty()
+  user: User;
+
+  @CreateDateColumn()
+  @ApiHideProperty()
+  @Exclude()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  @ApiHideProperty()
+  @Exclude()
+  updatedAt: Date;
+}

--- a/src/popo/user/user.entity.ts
+++ b/src/popo/user/user.entity.ts
@@ -4,12 +4,14 @@ import {
   CreateDateColumn,
   Entity,
   OneToMany,
+  OneToOne,
   PrimaryGeneratedColumn,
   Unique,
 } from 'typeorm';
 import { UserStatus, UserType } from './user.meta';
 import { ReserveEquip } from '../reservation/equip/reserve.equip.entity';
 import { ReservePlace } from '../reservation/place/reserve.place.entity';
+import { Nickname } from './nickname.entity';
 
 @Entity()
 @Unique(['email'])
@@ -56,4 +58,7 @@ export class User extends BaseEntity {
     (place_reservation) => place_reservation.booker,
   )
   place_reservation: ReservePlace[];
+
+  @OneToOne(() => Nickname, (nickname) => nickname.user)
+  nickname: Nickname;
 }

--- a/src/popo/user/user.module.ts
+++ b/src/popo/user/user.module.ts
@@ -4,9 +4,10 @@ import { UserController } from './user.controller';
 import { UserService } from './user.service';
 import { User } from './user.entity';
 import { SettingModule } from '../setting/setting.module';
+import { Nickname } from './nickname.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), SettingModule],
+  imports: [TypeOrmModule.forFeature([User, Nickname]), SettingModule],
   controllers: [UserController],
   providers: [UserService],
   exports: [UserService],

--- a/src/popo/user/user.service.ts
+++ b/src/popo/user/user.service.ts
@@ -7,6 +7,7 @@ import { User } from './user.entity';
 import { CreateUserDto, UpdateUserDto } from './user.dto';
 import { UserStatus, UserType } from './user.meta';
 import { SettingService } from '../setting/setting.service';
+import { Nickname } from './nickname.entity';
 
 const Message = {
   EXISTING_EMAIL: 'This email is already used.',
@@ -19,6 +20,8 @@ export class UserService {
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
     private readonly settingService: SettingService,
+    @InjectRepository(Nickname)
+    private readonly nicknameRepo: Repository<Nickname>,
   ) {}
 
   async save(dto: CreateUserDto) {
@@ -40,6 +43,7 @@ export class UserService {
       name: dto.name,
       userType: isRcStudent ? UserType.rc_student : dto.userType,
       lastLoginAt: new Date(),
+      userStatus: UserStatus.activated,
     });
   }
 
@@ -195,5 +199,17 @@ export class UserService {
     return crypto
       .pbkdf2Sync(password, cryptoSalt, 10000, 64, 'sha512')
       .toString('base64');
+  }
+
+  async getNickname(userUuid: string) {
+    const nickname = await this.nicknameRepo.findOne({
+      where: { userUuid },
+    });
+
+    if (!nickname) {
+      return { nickname: null };
+    }
+
+    return nickname;
   }
 }


### PR DESCRIPTION
paxi의 닉네임 선행 검증 및 쉬운 획득 [이슈](https://github.com/PoApper/paxi-popo-nest-api/issues/65)를 위해 POPO에서 쿠키 발급 시 유저의 닉네임도 함께 싣습니다. 닉네임이 없을 시 null로 세팅됩니다.

+Paxi에서는 User 테이블을 최대한 건드리지 않기 위해서 Nickname 테이블을 따로 만들었는데, 복잡도가 괜히 올라가는 느낌도 드네요.. 기존 User 테이블에 nickname 칼럼을 추가하고 관리해도 행, 열 충돌에 있어 상관없으려나요?