### PR TITLE
Fix: Put passthrough option when controller both sets http contents a…

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -80,7 +80,7 @@ export class AuthController {
   @Public()
   @Post(['login', 'login/admin'])
   @UseGuards(LocalAuthGuard)
-  async logIn(@Req() req: Request, @Res() res: Response) {
+  async logIn(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
     const path = req.path;
     const user = req.user as JwtPayload;
 
@@ -98,12 +98,12 @@ export class AuthController {
     const existUser = await this.userService.findOneByUuidOrFail(user.uuid);
     await this.userService.updateLogin(existUser.uuid);
 
-    return res.send(user);
+    return user;
   }
 
   @ApiCookieAuth()
   @Get('logout')
-  async logOut(@User() user: JwtPayload, @Res() res: Response) {
+  async logOut(@User() user: JwtPayload, @Res({ passthrough: true }) res: Response) {
     await this.userService.updateLogin(user.uuid);
     await this.userService.updateRefreshToken(user.uuid, null, null);
 
@@ -199,7 +199,7 @@ export class AuthController {
   })
   @Public()
   @Post('refresh')
-  async refresh(@Req() req: Request, @Res() res: Response) {
+  async refresh(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
     const accessTokenInCookie = req.cookies?.Authentication;
     const refreshTokenInCookie = req.cookies?.Refresh;
 
@@ -231,7 +231,7 @@ export class AuthController {
 
     this.setCookies(res, accessToken, refreshToken);
 
-    return res.send(user);
+    return user;
   }
 
   private setCookies(

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -103,13 +103,17 @@ export class AuthController {
 
   @ApiCookieAuth()
   @Get('logout')
-  async logOut(@User() user: JwtPayload, @Res({ passthrough: true }) res: Response) {
+  async logOut(
+    @User() user: JwtPayload,
+    @Res({ passthrough: true }) res: Response,
+  ) {
     await this.userService.updateLogin(user.uuid);
     await this.userService.updateRefreshToken(user.uuid, null, null);
 
     this.clearCookies(res);
+    res.sendStatus(200);
 
-    return res.sendStatus(200);
+    return { message: 'Successfully logged out' };
   }
 
   @Public()
@@ -199,7 +203,10 @@ export class AuthController {
   })
   @Public()
   @Post('refresh')
-  async refresh(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+  async refresh(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ) {
     const accessTokenInCookie = req.cookies?.Authentication;
     const refreshTokenInCookie = req.cookies?.Refresh;
 


### PR DESCRIPTION
https://docs.nestjs.com/controllers

> To use both approaches at the same time (for example, by injecting the response object to only set cookies/headers but still leave the rest to the framework), you must set the passthrough option to true in the @Res({ passthrough: true }) decorator.

컨트롤러에서 http 값 변경을 하면서도 객체를 return 할 때 권장되는 방법으로 passthrough = true 설정