### PR TITLE
Fix: Delete send() because nest will handle it

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -111,7 +111,6 @@ export class AuthController {
     await this.userService.updateRefreshToken(user.uuid, null, null);
 
     this.clearCookies(res);
-    res.sendStatus(200);
 
     return { message: 'Successfully logged out' };
   }


### PR DESCRIPTION
`{ passthrough: true }` 옵션 넣은 후에 생긴 문제
logout 로직에서 이미 res.send(200) 후에 nest 에서 자체적으로 200 응답을 또 보내려고 해서 생기는 오류 해결
res.send()를 지움

```
[Nest] 17  - 10/02/2025, 3:09:09 PM   ERROR [ExceptionsHandler] Cannot set headers after they are sent to the client

Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client

    at ServerResponse.setHeader (node:_http_outgoing:655:11)

    at ServerResponse.header (/usr/src/app/node_modules/@nestjs/platform-express/node_modules/express/lib/response.js:794:10)

    at ServerResponse.send (/usr/src/app/node_modules/@nestjs/platform-express/node_modules/express/lib/response.js:174:12)

    at ServerResponse.json (/usr/src/app/node_modules/@nestjs/platform-express/node_modules/express/lib/response.js:278:15)

    at ExpressAdapter.reply (/usr/src/app/node_modules/@nestjs/platform-express/adapters/express-adapter.js:62:62)

    at RouterResponseController.apply (/usr/src/app/node_modules/@nestjs/core/router/router-response-controller.js:15:36)

    at /usr/src/app/node_modules/@nestjs/core/router/router-execution-context.js:176:48

    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

    at async /usr/src/app/node_modules/@nestjs/core/router/router-execution-context.js:47:13

    at async /usr/src/app/node_modules/@nestjs/core/router/router-proxy.js:9:17
```

