### PR TITLE
Update: Limit number of db connections to 1 if it's not in prod

### DIFF
--- a/src/config/configurations.ts
+++ b/src/config/configurations.ts
@@ -25,10 +25,12 @@ export default () => {
       dropSchema: isTest, // ✅ 테스트 시 DB 초기화
       charset: isTest ? undefined : 'utf8mb4', // 테스트 환경인 SQLite는 기본적으로 MYSQL의 utf8mb4까지 커버하므로 따로 설정 필요하지 않음
 
-      extra: isTest ? undefined : {
-        // 커넥션 제한 안하면 터미널이나 로컬 개발 환경에서 too many connections 맞을 수 있음
-        connectionLimit: isProd ? 10 : 1,
-      },
+      extra: isTest
+        ? undefined
+        : {
+            // 커넥션 제한 안하면 터미널이나 로컬 개발 환경에서 too many connections 맞을 수 있음
+            connectionLimit: isProd ? 10 : 1,
+          },
     },
     // Paxi의 FCM과 같은 설정 사용
     firebase: {


### PR DESCRIPTION
prod 환경 아닐 때 connection limit을 제한함. connection 상방 치면서 로컬 개발 환경에서 db 접속 못하는 문제를 해결