### PR TITLE
feat: add audit log on reservation management

### DIFF
--- a/src/popo/reservation/equip/reserve.equip.controller.ts
+++ b/src/popo/reservation/equip/reserve.equip.controller.ts
@@ -197,7 +197,7 @@ export class ReserveEquipController {
     const reservation = await this.reserveEquipService.findOneByUuid(uuid);
 
     if (user.userType == UserType.admin || user.userType == UserType.staff) {
-      await this.reserveEquipService.remove(uuid);
+      await this.reserveEquipService.remove(uuid, user);
     } else {
       if (reservation.bookerId == user.uuid) {
         // if the reservation is in the past, deny delete
@@ -207,7 +207,7 @@ export class ReserveEquipController {
         if (reservationEndTime < currentTime) {
           throw new BadRequestException('Cannot delete past reservation');
         } else {
-          await this.reserveEquipService.remove(uuid);
+          await this.reserveEquipService.remove(uuid, user);
         }
       } else {
         throw new UnauthorizedException('Unauthorized delete action');
@@ -228,6 +228,7 @@ export class ReserveEquipController {
     @Param('uuid') uuid: string,
     @Param('status') status: ReservationStatus,
     @Query('sendEmail') sendEmail?: boolean,
+    @User() user?: JwtPayload,
   ) {
     const reservation =
       await this.reserveEquipService.findOneByUuidOrFail(uuid);
@@ -245,7 +246,12 @@ export class ReserveEquipController {
       }
     }
 
-    const response = await this.reserveEquipService.updateStatus(uuid, status);
+    const response = await this.reserveEquipService.updateStatus(
+      uuid,
+      status,
+      user,
+      '단건 상태 변경',
+    );
 
     if (sendEmail) {
       // Send e-mail to client.

--- a/src/popo/reservation/equip/reserve.equip.service.ts
+++ b/src/popo/reservation/equip/reserve.equip.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Like, Repository } from 'typeorm';
 import { ReserveEquip } from './reserve.equip.entity';
@@ -6,10 +6,12 @@ import { CreateReserveEquipDto } from './reserve.equip.dto';
 import { UserService } from '../../user/user.service';
 import { EquipService } from '../../equip/equip.service';
 import { ReservationStatus } from '../reservation.meta';
+import { JwtPayload } from '../../../auth/strategies/jwt.payload';
 import {
   calculateReservationDurationMinutes,
   timeStringToMinutes,
 } from '../../../utils/reservation-utils';
+import { UserType } from '../../user/user.meta';
 
 const Message = {
   NOT_EXISTING_USER: "There's no such user.",
@@ -25,6 +27,8 @@ const Message = {
 
 @Injectable()
 export class ReserveEquipService {
+  private readonly logger = new Logger(ReserveEquipService.name);
+
   constructor(
     @InjectRepository(ReserveEquip)
     private readonly reserveEquipRepo: Repository<ReserveEquip>,
@@ -158,12 +162,39 @@ export class ReserveEquipService {
     return this.reserveEquipRepo.findOneByOrFail({ uuid: uuid });
   }
 
-  remove(uuid: string) {
-    return this.reserveEquipRepo.delete(uuid);
+  async remove(uuid: string, actor?: JwtPayload) {
+    const reservation = await this.findOneByUuidOrFail(uuid);
+    const result = await this.reserveEquipRepo.delete(uuid);
+
+    if (this.isAdminActor(actor)) {
+      const actorName = actor.name ?? actor.nickname ?? '(이름 없음)';
+      this.logger.log(
+        [
+          '[관리자 장비 예약 삭제]',
+          `- 관리자 UUID: ${actor.uuid}`,
+          `- 관리자 이름: ${actorName}`,
+          `- 관리자 권한: ${actor.userType}`,
+          `- 예약 UUID: ${reservation.uuid}`,
+          `- 예약 제목: ${reservation.title}`,
+          `- 예약자 UUID: ${reservation.bookerId}`,
+          `- 장비 UUID 목록: [${reservation.equipments.join(', ')}]`,
+          `- 예약 일시: ${reservation.date} ${reservation.startTime}~${reservation.endTime}`,
+          `- 삭제 당시 상태: "${reservation.status}"`,
+        ].join('\n'),
+      );
+    }
+
+    return result;
   }
 
-  async updateStatus(uuid: string, status: ReservationStatus) {
+  async updateStatus(
+    uuid: string,
+    status: ReservationStatus,
+    actor?: JwtPayload,
+    actionContext: string = '단건 상태 변경',
+  ) {
     const existReserve = await this.findOneByUuidOrFail(uuid);
+    const previousStatus = existReserve.status;
 
     await this.reserveEquipRepo.update(
       { uuid: uuid },
@@ -176,11 +207,39 @@ export class ReserveEquipService {
       existReserve.bookerId,
     );
 
+    if (this.isAdminActor(actor)) {
+      const actorName = actor.name ?? actor.nickname ?? '(이름 없음)';
+      this.logger.log(
+        [
+          '[관리자 장비 예약 상태 변경]',
+          `- 행동: ${actionContext}`,
+          `- 관리자 UUID: ${actor.uuid}`,
+          `- 관리자 이름: ${actorName}`,
+          `- 관리자 권한: ${actor.userType}`,
+          `- 예약 UUID: ${existReserve.uuid}`,
+          `- 예약 제목: ${existReserve.title}`,
+          `- 예약자 UUID: ${existReserve.bookerId}`,
+          `- 장비 UUID 목록: [${existReserve.equipments.join(', ')}]`,
+          `- 예약 일시: ${existReserve.date} ${existReserve.startTime}~${existReserve.endTime}`,
+          `- 상태 변경: "${previousStatus}" -> "${status}"`,
+        ].join('\n'),
+      );
+    }
+
     return {
       userType: existUser.userType,
       email: existUser.email,
       title: existReserve.title,
     };
+  }
+
+  private isAdminActor(actor?: JwtPayload) {
+    return (
+      !!actor &&
+      [UserType.admin, UserType.association, UserType.staff].includes(
+        actor.userType,
+      )
+    );
   }
 
   async joinBooker(reservations) {

--- a/src/popo/reservation/place/reserve.place.controller.ts
+++ b/src/popo/reservation/place/reserve.place.controller.ts
@@ -240,6 +240,7 @@ export class ReservePlaceController {
   async acceptAllStatus(
     @Body() body: AcceptPlaceReservationListDto,
     @Query('sendEmail') sendEmail?: string,
+    @User() user?: JwtPayload,
   ) {
     const reservations: ReservePlace[] = [];
     for (const reservationUuid of body.uuidList) {
@@ -265,6 +266,8 @@ export class ReservePlaceController {
       const response = await this.reservePlaceService.updateStatus(
         reservation.uuid,
         ReservationStatus.accept,
+        user,
+        '일괄 승인',
       );
 
       if (sendEmail === 'true') {
@@ -289,6 +292,7 @@ export class ReservePlaceController {
     @Param('uuid') uuid: string,
     @Param('status') status: ReservationStatus,
     @Query('sendEmail') sendEmail?: string,
+    @User() user?: JwtPayload,
   ) {
     const reservation =
       await this.reservePlaceService.findOneByUuidOrFail(uuid);
@@ -306,7 +310,12 @@ export class ReservePlaceController {
       );
     }
 
-    const response = await this.reservePlaceService.updateStatus(uuid, status);
+    const response = await this.reservePlaceService.updateStatus(
+      uuid,
+      status,
+      user,
+      '단건 상태 변경',
+    );
 
     if (sendEmail === 'true') {
       // Send e-mail to client.
@@ -328,7 +337,7 @@ export class ReservePlaceController {
       await this.reservePlaceService.findOneByUuidOrFail(uuid);
 
     if (user.userType == UserType.admin || user.userType == UserType.staff) {
-      await this.reservePlaceService.remove(uuid);
+      await this.reservePlaceService.remove(uuid, user);
     } else {
       if (reservation.bookerId === user.uuid) {
         // if the reservation is in the past, deny delete
@@ -338,7 +347,7 @@ export class ReservePlaceController {
         if (reservationEndTime < currentTime) {
           throw new BadRequestException('Cannot delete past reservation');
         } else {
-          await this.reservePlaceService.remove(uuid);
+          await this.reservePlaceService.remove(uuid, user);
         }
       } else {
         throw new UnauthorizedException('Unauthorized delete action');

--- a/src/popo/reservation/place/reserve.place.service.ts
+++ b/src/popo/reservation/place/reserve.place.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ReservePlace } from './reserve.place.entity';
 import { DeepPartial, In, MoreThanOrEqual, Repository } from 'typeorm';
@@ -7,6 +7,7 @@ import { UserService } from '../../user/user.service';
 import { PlaceService } from '../../place/place.service';
 import { ReservationStatus } from '../reservation.meta';
 import { PlaceEnableAutoAccept, PlaceRegion } from '../../place/place.meta';
+import { JwtPayload } from '../../../auth/strategies/jwt.payload';
 import {
   calculateReservationDurationMinutes,
   timeStringToMinutes,
@@ -25,6 +26,8 @@ const Message = {
 
 @Injectable()
 export class ReservePlaceService {
+  private readonly logger = new Logger(ReservePlaceService.name);
+
   constructor(
     @InjectRepository(ReservePlace)
     private readonly reservePlaceRepo: Repository<ReservePlace>,
@@ -233,8 +236,14 @@ export class ReservePlaceService {
     });
   }
 
-  async updateStatus(uuid: string, status: ReservationStatus) {
+  async updateStatus(
+    uuid: string,
+    status: ReservationStatus,
+    actor?: JwtPayload,
+    actionContext: string = '단건 상태 변경',
+  ) {
     const existReserve = await this.findOneByUuidOrFail(uuid);
+    const previousStatus = existReserve.status;
 
     if (!existReserve) {
       throw new BadRequestException(Message.NOT_EXISTING_RESERVATION);
@@ -251,6 +260,25 @@ export class ReservePlaceService {
       existReserve.bookerId,
     );
 
+    if (this.isAdminActor(actor)) {
+      const actorName = actor.name ?? actor.nickname ?? '(이름 없음)';
+      this.logger.log(
+        [
+          '[관리자 장소 예약 상태 변경]',
+          `- 행동: ${actionContext}`,
+          `- 관리자 UUID: ${actor.uuid}`,
+          `- 관리자 이름: ${actorName}`,
+          `- 관리자 권한: ${actor.userType}`,
+          `- 예약 UUID: ${existReserve.uuid}`,
+          `- 예약 제목: ${existReserve.title}`,
+          `- 예약자 UUID: ${existReserve.bookerId}`,
+          `- 장소 UUID: ${existReserve.placeId}`,
+          `- 예약 일시: ${existReserve.date} ${existReserve.startTime}~${existReserve.endTime}`,
+          `- 상태 변경: "${previousStatus}" -> "${status}"`,
+        ].join('\n'),
+      );
+    }
+
     return {
       userType: existUser.userType,
       email: existUser.email,
@@ -258,8 +286,38 @@ export class ReservePlaceService {
     };
   }
 
-  remove(uuid: string) {
-    return this.reservePlaceRepo.delete(uuid);
+  async remove(uuid: string, actor?: JwtPayload) {
+    const reservation = await this.findOneByUuidOrFail(uuid);
+    const result = await this.reservePlaceRepo.delete(uuid);
+
+    if (this.isAdminActor(actor)) {
+      const actorName = actor.name ?? actor.nickname ?? '(이름 없음)';
+      this.logger.log(
+        [
+          '[관리자 장소 예약 삭제]',
+          `- 관리자 UUID: ${actor.uuid}`,
+          `- 관리자 이름: ${actorName}`,
+          `- 관리자 권한: ${actor.userType}`,
+          `- 예약 UUID: ${reservation.uuid}`,
+          `- 예약 제목: ${reservation.title}`,
+          `- 예약자 UUID: ${reservation.bookerId}`,
+          `- 장소 UUID: ${reservation.placeId}`,
+          `- 예약 일시: ${reservation.date} ${reservation.startTime}~${reservation.endTime}`,
+          `- 삭제 당시 상태: "${reservation.status}"`,
+        ].join('\n'),
+      );
+    }
+
+    return result;
+  }
+
+  private isAdminActor(actor?: JwtPayload) {
+    return (
+      !!actor &&
+      [UserType.admin, UserType.association, UserType.staff].includes(
+        actor.userType,
+      )
+    );
   }
 
   async joinBooker(reservations) {


### PR DESCRIPTION
<img width="1505" height="1047" alt="image" src="https://github.com/user-attachments/assets/30335490-48c5-4ed8-bc29-30e29aae3fb7" />
* 관리자가 예약을 승인, 거절, 삭제 시 로깅을 추가.
[#](https://github.com/PoApper/popo-admin-web/issues/140)