### PR TITLE
feat(auth): 인증 로깅 강화

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -231,7 +231,10 @@ export class AuthController {
     @User() user: JwtPayload,
     @Body() body: PasswordUpdateRequest,
   ) {
-    const result = await this.userService.updatePasswordByEmail(user.email, body.password);
+    const result = await this.userService.updatePasswordByEmail(
+      user.email,
+      body.password,
+    );
 
     this.logger.log(
       [

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -3,7 +3,6 @@ import {
   Body,
   Controller,
   Get,
-  Logger,
   Param,
   Post,
   Put,
@@ -23,6 +22,7 @@ import { ReservePlaceService } from '../popo/reservation/place/reserve.place.ser
 import { ReserveEquipService } from '../popo/reservation/equip/reserve.equip.service';
 import { ApiBody, ApiCookieAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtPayload } from './strategies/jwt.payload';
+import { AuthLogger } from './auth.logger';
 import { PasswordResetRequest, PasswordUpdateRequest } from './auth.dto';
 import { jwtConstants } from './constants';
 import * as ms from 'ms';
@@ -39,7 +39,7 @@ const Message = {
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
-  private readonly logger = new Logger(AuthController.name);
+  private readonly logger = new AuthLogger(AuthController.name);
 
   constructor(
     private readonly authService: AuthService,
@@ -145,13 +145,10 @@ export class AuthController {
   @Post(['signIn', 'register'])
   async register(@Body() createUserDto: CreateUserDto) {
     const saveUser = await this.userService.save(createUserDto);
-    this.logger.log(
-      [
-        '[회원가입 성공]',
-        `- 이메일: ${saveUser.email}`,
-        `- 유저 UUID: ${saveUser.uuid}`,
-      ].join('\n'),
-    );
+    this.logger.log('회원가입 성공', {
+      이메일: saveUser.email,
+      '유저 UUID': saveUser.uuid,
+    });
 
     try {
       await this.mailService.sendVerificationMail(
@@ -160,13 +157,13 @@ export class AuthController {
       );
     } catch (error) {
       this.logger.error(
-        [
-          '[회원가입 실패: 인증 메일 전송 실패]',
-          `- 이메일: ${createUserDto.email}`,
-          `- 유저 UUID: ${saveUser.uuid}`,
-          `- 에러: ${error instanceof Error ? error.message : String(error)}`,
-        ].join('\n'),
-        error instanceof Error ? error.stack : String(error),
+        '회원가입 실패: 인증 메일 전송 실패',
+        {
+          이메일: createUserDto.email,
+          '유저 UUID': saveUser.uuid,
+          에러: error instanceof Error ? error.message : String(error),
+        },
+        error instanceof Error ? error.stack : undefined,
       );
       await this.userService.remove(saveUser.uuid);
       throw new BadRequestException(Message.FAIL_VERIFICATION_EMAIL_SEND);
@@ -187,25 +184,19 @@ export class AuthController {
     const existUser = await this.userService.findOneByEmail(body.email);
 
     if (!existUser) {
-      this.logger.warn(
-        [
-          '[비밀번호 초기화 실패: 존재하지 않는 이메일]',
-          `- 시도 이메일: ${body.email}`,
-        ].join('\n'),
-      );
+      this.logger.warn('비밀번호 초기화 실패: 존재하지 않는 이메일', {
+        '시도 이메일': body.email,
+      });
       throw new BadRequestException(
         '해당 이메일로 가입한 유저가 존재하지 않습니다.',
       );
     }
 
     if (existUser.userStatus === UserStatus.password_reset) {
-      this.logger.warn(
-        [
-          '[비밀번호 초기화 실패: 이미 초기화된 계정]',
-          `- 이메일: ${body.email}`,
-          `- 유저 UUID: ${existUser.uuid}`,
-        ].join('\n'),
-      );
+      this.logger.warn('비밀번호 초기화 실패: 이미 초기화된 계정', {
+        이메일: body.email,
+        '유저 UUID': existUser.uuid,
+      });
       throw new BadRequestException(
         '이미 비빌번호를 초기화 했습니다. 신규 비밀번호를 메일에서 확인해주세요.',
       );
@@ -226,13 +217,10 @@ export class AuthController {
       temp_password,
     );
 
-    this.logger.log(
-      [
-        '[비밀번호 초기화 성공]',
-        `- 이메일: ${existUser.email}`,
-        `- 유저 UUID: ${existUser.uuid}`,
-      ].join('\n'),
-    );
+    this.logger.log('비밀번호 초기화 성공', {
+      이메일: existUser.email,
+      '유저 UUID': existUser.uuid,
+    });
   }
 
   @ApiCookieAuth()
@@ -246,13 +234,10 @@ export class AuthController {
       body.password,
     );
 
-    this.logger.log(
-      [
-        '[비밀번호 변경]',
-        `- 이메일: ${user.email}`,
-        `- 유저 UUID: ${user.uuid}`,
-      ].join('\n'),
-    );
+    this.logger.log('비밀번호 변경', {
+      이메일: user.email,
+      '유저 UUID': user.uuid,
+    });
 
     return result;
   }
@@ -282,14 +267,11 @@ export class AuthController {
     const refreshTokenInCookie = req.cookies?.Refresh;
 
     if (!accessTokenInCookie || !refreshTokenInCookie) {
-      this.logger.warn(
-        [
-          '[토큰 갱신 실패: 쿠키 누락]',
-          `- Access Token 존재: ${!!accessTokenInCookie}`,
-          `- Refresh Token 존재: ${!!refreshTokenInCookie}`,
-          `- User-Agent: ${this.getUserAgent(req)}`,
-        ].join('\n'),
-      );
+      this.logger.warn('토큰 갱신 실패: 쿠키 누락', {
+        'Access Token 존재': !!accessTokenInCookie,
+        'Refresh Token 존재': !!refreshTokenInCookie,
+        'User-Agent': this.getUserAgent(req),
+      });
       this.clearCookies(res);
       throw new UnauthorizedException('Missing access token or refresh token');
     }
@@ -297,12 +279,9 @@ export class AuthController {
     // 만료된 access token을 디코딩 (JWT 가드 우회)
     const user = this.authService.decodeExpiredAccessToken(accessTokenInCookie);
     if (!user) {
-      this.logger.warn(
-        [
-          '[토큰 갱신 실패: Access Token 디코딩 실패]',
-          `- User-Agent: ${this.getUserAgent(req)}`,
-        ].join('\n'),
-      );
+      this.logger.warn('토큰 갱신 실패: Access Token 디코딩 실패', {
+        'User-Agent': this.getUserAgent(req),
+      });
       this.clearCookies(res);
       throw new UnauthorizedException('Invalid access token');
     }
@@ -313,14 +292,11 @@ export class AuthController {
       refreshTokenInCookie,
     );
     if (!isValid) {
-      this.logger.warn(
-        [
-          '[토큰 갱신 실패: Refresh Token 검증 실패]',
-          `- 유저 UUID: ${user.uuid}`,
-          `- 이메일: ${user.email}`,
-          `- User-Agent: ${this.getUserAgent(req)}`,
-        ].join('\n'),
-      );
+      this.logger.warn('토큰 갱신 실패: Refresh Token 검증 실패', {
+        '유저 UUID': user.uuid,
+        이메일: user.email,
+        'User-Agent': this.getUserAgent(req),
+      });
       await this.userService.updateRefreshToken(user.uuid, null, null);
       this.clearCookies(res);
       throw new UnauthorizedException('Invalid refresh token');
@@ -331,14 +307,11 @@ export class AuthController {
 
     this.setCookies(res, accessToken, refreshToken);
 
-    this.logger.log(
-      [
-        '[토큰 갱신 성공]',
-        `- 유저 UUID: ${user.uuid}`,
-        `- 이메일: ${user.email}`,
-        `- User-Agent: ${this.getUserAgent(req)}`,
-      ].join('\n'),
-    );
+    this.logger.log('토큰 갱신 성공', {
+      '유저 UUID': user.uuid,
+      이메일: user.email,
+      'User-Agent': this.getUserAgent(req),
+    });
 
     return user;
   }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -50,7 +50,16 @@ export class AuthController {
   ) {}
 
   private getUserAgent(req: Request): string {
-    return req.headers['user-agent'] || '(알 수 없음)';
+    const userAgent = req.headers['user-agent'];
+    if (!userAgent) {
+      return '(알 수 없음)';
+    }
+
+    const normalizedUserAgent = Array.isArray(userAgent)
+      ? userAgent.join(', ')
+      : String(userAgent);
+
+    return normalizedUserAgent.replace(/[\r\n]/g, '');
   }
 
   @ApiCookieAuth()
@@ -155,8 +164,9 @@ export class AuthController {
           '[회원가입 실패: 인증 메일 전송 실패]',
           `- 이메일: ${createUserDto.email}`,
           `- 유저 UUID: ${saveUser.uuid}`,
-          `- 에러: ${error.message}`,
+          `- 에러: ${error instanceof Error ? error.message : String(error)}`,
         ].join('\n'),
+        error instanceof Error ? error.stack : String(error),
       );
       await this.userService.remove(saveUser.uuid);
       throw new BadRequestException(Message.FAIL_VERIFICATION_EMAIL_SEND);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -177,12 +177,25 @@ export class AuthController {
     const existUser = await this.userService.findOneByEmail(body.email);
 
     if (!existUser) {
+      this.logger.warn(
+        [
+          '[비밀번호 초기화 실패: 존재하지 않는 이메일]',
+          `- 시도 이메일: ${body.email}`,
+        ].join('\n'),
+      );
       throw new BadRequestException(
         '해당 이메일로 가입한 유저가 존재하지 않습니다.',
       );
     }
 
     if (existUser.userStatus === UserStatus.password_reset) {
+      this.logger.warn(
+        [
+          '[비밀번호 초기화 실패: 이미 초기화된 계정]',
+          `- 이메일: ${body.email}`,
+          `- 유저 UUID: ${existUser.uuid}`,
+        ].join('\n'),
+      );
       throw new BadRequestException(
         '이미 비빌번호를 초기화 했습니다. 신규 비밀번호를 메일에서 확인해주세요.',
       );
@@ -202,6 +215,14 @@ export class AuthController {
       existUser.email,
       temp_password,
     );
+
+    this.logger.log(
+      [
+        '[비밀번호 초기화 성공]',
+        `- 이메일: ${existUser.email}`,
+        `- 유저 UUID: ${existUser.uuid}`,
+      ].join('\n'),
+    );
   }
 
   @ApiCookieAuth()
@@ -210,7 +231,17 @@ export class AuthController {
     @User() user: JwtPayload,
     @Body() body: PasswordUpdateRequest,
   ) {
-    return this.userService.updatePasswordByEmail(user.email, body.password);
+    const result = await this.userService.updatePasswordByEmail(user.email, body.password);
+
+    this.logger.log(
+      [
+        '[비밀번호 변경]',
+        `- 이메일: ${user.email}`,
+        `- 유저 UUID: ${user.uuid}`,
+      ].join('\n'),
+    );
+
+    return result;
   }
 
   @ApiCookieAuth()

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -238,6 +238,14 @@ export class AuthController {
     const refreshTokenInCookie = req.cookies?.Refresh;
 
     if (!accessTokenInCookie || !refreshTokenInCookie) {
+      this.logger.warn(
+        [
+          '[토큰 갱신 실패: 쿠키 누락]',
+          `- Access Token 존재: ${!!accessTokenInCookie}`,
+          `- Refresh Token 존재: ${!!refreshTokenInCookie}`,
+          `- User-Agent: ${this.getUserAgent(req)}`,
+        ].join('\n'),
+      );
       this.clearCookies(res);
       throw new UnauthorizedException('Missing access token or refresh token');
     }
@@ -245,6 +253,12 @@ export class AuthController {
     // 만료된 access token을 디코딩 (JWT 가드 우회)
     const user = this.authService.decodeExpiredAccessToken(accessTokenInCookie);
     if (!user) {
+      this.logger.warn(
+        [
+          '[토큰 갱신 실패: Access Token 디코딩 실패]',
+          `- User-Agent: ${this.getUserAgent(req)}`,
+        ].join('\n'),
+      );
       this.clearCookies(res);
       throw new UnauthorizedException('Invalid access token');
     }
@@ -255,6 +269,14 @@ export class AuthController {
       refreshTokenInCookie,
     );
     if (!isValid) {
+      this.logger.warn(
+        [
+          '[토큰 갱신 실패: Refresh Token 검증 실패]',
+          `- 유저 UUID: ${user.uuid}`,
+          `- 이메일: ${user.email}`,
+          `- User-Agent: ${this.getUserAgent(req)}`,
+        ].join('\n'),
+      );
       await this.userService.updateRefreshToken(user.uuid, null, null);
       this.clearCookies(res);
       throw new UnauthorizedException('Invalid refresh token');
@@ -264,6 +286,15 @@ export class AuthController {
     const refreshToken = await this.authService.generateRefreshToken(user);
 
     this.setCookies(res, accessToken, refreshToken);
+
+    this.logger.log(
+      [
+        '[토큰 갱신 성공]',
+        `- 유저 UUID: ${user.uuid}`,
+        `- 이메일: ${user.email}`,
+        `- User-Agent: ${this.getUserAgent(req)}`,
+      ].join('\n'),
+    );
 
     return user;
   }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -136,7 +136,13 @@ export class AuthController {
   @Post(['signIn', 'register'])
   async register(@Body() createUserDto: CreateUserDto) {
     const saveUser = await this.userService.save(createUserDto);
-    console.log('유저 생성 성공!', saveUser.name, saveUser.email); // TODO: console.log 로깅으로 변경
+    this.logger.log(
+      [
+        '[회원가입 성공]',
+        `- 이메일: ${saveUser.email}`,
+        `- 유저 UUID: ${saveUser.uuid}`,
+      ].join('\n'),
+    );
 
     try {
       await this.mailService.sendVerificationMail(
@@ -144,9 +150,15 @@ export class AuthController {
         saveUser.uuid,
       );
     } catch (error) {
-      console.log('!! 유저 인증 메일 전송 실패 !!');
+      this.logger.error(
+        [
+          '[회원가입 실패: 인증 메일 전송 실패]',
+          `- 이메일: ${createUserDto.email}`,
+          `- 유저 UUID: ${saveUser.uuid}`,
+          `- 에러: ${error.message}`,
+        ].join('\n'),
+      );
       await this.userService.remove(saveUser.uuid);
-      console.log('잘못 생성된 유저 정보를 DB에서 삭제합니다.');
       throw new BadRequestException(Message.FAIL_VERIFICATION_EMAIL_SEND);
     }
     return saveUser;

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import {
   Body,
   Controller,
   Get,
+  Logger,
   Param,
   Post,
   Put,
@@ -20,7 +21,7 @@ import { CreateUserDto } from '../popo/user/user.dto';
 import { MailService } from '../mail/mail.service';
 import { ReservePlaceService } from '../popo/reservation/place/reserve.place.service';
 import { ReserveEquipService } from '../popo/reservation/equip/reserve.equip.service';
-import { ApiCookieAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiCookieAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtPayload } from './strategies/jwt.payload';
 import { PasswordResetRequest, PasswordUpdateRequest } from './auth.dto';
 import { jwtConstants } from './constants';
@@ -38,6 +39,8 @@ const Message = {
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
+  private readonly logger = new Logger(AuthController.name);
+
   constructor(
     private readonly authService: AuthService,
     private readonly userService: UserService,
@@ -45,6 +48,10 @@ export class AuthController {
     private readonly reserveEquipService: ReserveEquipService,
     private readonly mailService: MailService,
   ) {}
+
+  private getUserAgent(req: Request): string {
+    return req.headers['user-agent'] || '(알 수 없음)';
+  }
 
   @ApiCookieAuth()
   @Get(['verifyToken', 'verifyToken/admin', 'me'])
@@ -81,6 +88,15 @@ export class AuthController {
   @Public()
   @Post(['login', 'login/admin'])
   @UseGuards(LocalAuthGuard)
+  @ApiBody({
+    schema: {
+      properties: {
+        email: { type: 'string' },
+        password: { type: 'string' },
+      },
+      required: ['email', 'password'],
+    },
+  })
   async logIn(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
     const path = req.path;
     const user = req.user as JwtPayload;

--- a/src/auth/auth.logger.ts
+++ b/src/auth/auth.logger.ts
@@ -1,0 +1,38 @@
+import { Logger } from '@nestjs/common';
+
+type LogFieldValue = string | number | boolean | null | undefined;
+type LogFields = Record<string, LogFieldValue>;
+
+export class AuthLogger {
+  private readonly logger: Logger;
+
+  constructor(context: string) {
+    this.logger = new Logger(context);
+  }
+
+  log(event: string, fields: LogFields): void {
+    this.logger.log(this.format(event, fields));
+  }
+
+  warn(event: string, fields: LogFields): void {
+    this.logger.warn(this.format(event, fields));
+  }
+
+  error(event: string, fields: LogFields, stack?: string): void {
+    this.logger.error(this.format(event, fields), stack);
+  }
+
+  private format(event: string, fields: LogFields): string {
+    const lines = [`[${event}]`];
+    for (const [key, value] of Object.entries(fields)) {
+      lines.push(`- ${key}: ${this.sanitize(value)}`);
+    }
+    return lines.join('\n');
+  }
+
+  private sanitize(value: LogFieldValue): string {
+    if (value == null) return '(없음)';
+    const str = String(value);
+    return str.replace(/[\r\n]/g, '');
+  }
+}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as crypto from 'crypto';
 import { UserService } from '../popo/user/user.service';
@@ -12,6 +12,8 @@ import * as ms from 'ms';
 
 @Injectable()
 export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
+
   constructor(
     private readonly usersService: UserService,
     private readonly jwtService: JwtService,
@@ -21,6 +23,12 @@ export class AuthService {
     const user = await this.usersService.findOneByEmail(email);
 
     if (!user) {
+      this.logger.warn(
+        [
+          '[로그인 실패: 존재하지 않는 이메일]',
+          `- 시도 이메일: ${email}`,
+        ].join('\n'),
+      );
       return null;
     }
 
@@ -29,6 +37,14 @@ export class AuthService {
     if (user.userStatus == UserStatus.password_reset) {
       await this.usersService.updateUserStatus(user.uuid, UserStatus.activated);
     } else if (user.userStatus != UserStatus.activated) {
+      this.logger.warn(
+        [
+          '[로그인 실패: 비활성 계정]',
+          `- 이메일: ${email}`,
+          `- 유저 UUID: ${user.uuid}`,
+          `- 계정 상태: ${user.userStatus}`,
+        ].join('\n'),
+      );
       throw new UnauthorizedException('Not activated account.');
     }
 
@@ -37,6 +53,13 @@ export class AuthService {
       const nickname = await this.usersService.getNickname(user.uuid);
       return { ...user, nickname: nickname.nickname };
     } else {
+      this.logger.warn(
+        [
+          '[로그인 실패: 비밀번호 불일치]',
+          `- 이메일: ${email}`,
+          `- 유저 UUID: ${user.uuid}`,
+        ].join('\n'),
+      );
       return null;
     }
   }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -19,14 +19,19 @@ export class AuthService {
     private readonly jwtService: JwtService,
   ) {}
 
+  private sanitizeForLog(value: string): string {
+    return value.replace(/[\r\n]/g, '');
+  }
+
   async validateUser(email: string, password: string): Promise<any> {
     const user = await this.usersService.findOneByEmail(email);
 
     if (!user) {
       this.logger.warn(
-        ['[로그인 실패: 존재하지 않는 이메일]', `- 시도 이메일: ${email}`].join(
-          '\n',
-        ),
+        [
+          '[로그인 실패: 존재하지 않는 이메일]',
+          `- 시도 이메일: ${this.sanitizeForLog(email)}`,
+        ].join('\n'),
       );
       return null;
     }
@@ -39,7 +44,7 @@ export class AuthService {
       this.logger.warn(
         [
           '[로그인 실패: 비활성 계정]',
-          `- 이메일: ${email}`,
+          `- 이메일: ${this.sanitizeForLog(email)}`,
           `- 유저 UUID: ${user.uuid}`,
           `- 계정 상태: ${user.userStatus}`,
         ].join('\n'),
@@ -55,7 +60,7 @@ export class AuthService {
       this.logger.warn(
         [
           '[로그인 실패: 비밀번호 불일치]',
-          `- 이메일: ${email}`,
+          `- 이메일: ${this.sanitizeForLog(email)}`,
           `- 유저 UUID: ${user.uuid}`,
         ].join('\n'),
       );
@@ -147,6 +152,18 @@ export class AuthService {
       const user = await this.usersService.findOneByUuid(
         userInAccessToken.uuid,
       );
+
+      if (!user) {
+        this.logger.warn(
+          [
+            '[토큰 갱신 실패: 존재하지 않는 유저]',
+            `- 유저 UUID: ${userInAccessToken.uuid}`,
+            `- 이메일: ${userInAccessToken.email}`,
+          ].join('\n'),
+        );
+        return false;
+      }
+
       const hashedToken = this.hashToken(refreshToken);
 
       if (!user.hashedRefreshToken || user.hashedRefreshToken !== hashedToken) {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,10 +1,11 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as crypto from 'crypto';
 import { UserService } from '../popo/user/user.service';
 import { UserStatus } from '../popo/user/user.meta';
 import { jwtConstants } from './constants';
 import { JwtPayload } from './strategies/jwt.payload';
+import { AuthLogger } from './auth.logger';
 import * as ms from 'ms';
 /**
  * retrieving a user and verifying the password.
@@ -12,27 +13,20 @@ import * as ms from 'ms';
 
 @Injectable()
 export class AuthService {
-  private readonly logger = new Logger(AuthService.name);
+  private readonly logger = new AuthLogger(AuthService.name);
 
   constructor(
     private readonly usersService: UserService,
     private readonly jwtService: JwtService,
   ) {}
 
-  private sanitizeForLog(value: string): string {
-    return value.replace(/[\r\n]/g, '');
-  }
-
   async validateUser(email: string, password: string): Promise<any> {
     const user = await this.usersService.findOneByEmail(email);
 
     if (!user) {
-      this.logger.warn(
-        [
-          '[로그인 실패: 존재하지 않는 이메일]',
-          `- 시도 이메일: ${this.sanitizeForLog(email)}`,
-        ].join('\n'),
-      );
+      this.logger.warn('로그인 실패: 존재하지 않는 이메일', {
+        '시도 이메일': email,
+      });
       return null;
     }
 
@@ -41,14 +35,11 @@ export class AuthService {
     if (user.userStatus == UserStatus.password_reset) {
       await this.usersService.updateUserStatus(user.uuid, UserStatus.activated);
     } else if (user.userStatus != UserStatus.activated) {
-      this.logger.warn(
-        [
-          '[로그인 실패: 비활성 계정]',
-          `- 이메일: ${this.sanitizeForLog(email)}`,
-          `- 유저 UUID: ${user.uuid}`,
-          `- 계정 상태: ${user.userStatus}`,
-        ].join('\n'),
-      );
+      this.logger.warn('로그인 실패: 비활성 계정', {
+        이메일: email,
+        '유저 UUID': user.uuid,
+        '계정 상태': user.userStatus,
+      });
       throw new UnauthorizedException('Not activated account.');
     }
 
@@ -57,13 +48,10 @@ export class AuthService {
       const nickname = await this.usersService.getNickname(user.uuid);
       return { ...user, nickname: nickname.nickname };
     } else {
-      this.logger.warn(
-        [
-          '[로그인 실패: 비밀번호 불일치]',
-          `- 이메일: ${this.sanitizeForLog(email)}`,
-          `- 유저 UUID: ${user.uuid}`,
-        ].join('\n'),
-      );
+      this.logger.warn('로그인 실패: 비밀번호 불일치', {
+        이메일: email,
+        '유저 UUID': user.uuid,
+      });
       return null;
     }
   }
@@ -137,14 +125,11 @@ export class AuthService {
 
       // 2. 리프레시 토큰의 payload가 액세스 토큰의 정보와 일치하는지 검증
       if (userInRefreshToken.uuid !== userInAccessToken.uuid) {
-        this.logger.warn(
-          [
-            '[토큰 갱신 실패: UUID 불일치]',
-            `- Access Token UUID: ${userInAccessToken.uuid}`,
-            `- Refresh Token UUID: ${userInRefreshToken.uuid}`,
-            `- 이메일: ${userInAccessToken.email}`,
-          ].join('\n'),
-        );
+        this.logger.warn('토큰 갱신 실패: UUID 불일치', {
+          'Access Token UUID': userInAccessToken.uuid,
+          'Refresh Token UUID': userInRefreshToken.uuid,
+          이메일: userInAccessToken.email,
+        });
         return false;
       }
 
@@ -154,27 +139,21 @@ export class AuthService {
       );
 
       if (!user) {
-        this.logger.warn(
-          [
-            '[토큰 갱신 실패: 존재하지 않는 유저]',
-            `- 유저 UUID: ${userInAccessToken.uuid}`,
-            `- 이메일: ${userInAccessToken.email}`,
-          ].join('\n'),
-        );
+        this.logger.warn('토큰 갱신 실패: 존재하지 않는 유저', {
+          '유저 UUID': userInAccessToken.uuid,
+          이메일: userInAccessToken.email,
+        });
         return false;
       }
 
       const hashedToken = this.hashToken(refreshToken);
 
       if (!user.hashedRefreshToken || user.hashedRefreshToken !== hashedToken) {
-        this.logger.warn(
-          [
-            '[토큰 갱신 실패: Refresh Token 해시 불일치]',
-            `- 유저 UUID: ${userInAccessToken.uuid}`,
-            `- 이메일: ${userInAccessToken.email}`,
-            `- DB에 토큰 존재 여부: ${!!user.hashedRefreshToken}`,
-          ].join('\n'),
-        );
+        this.logger.warn('토큰 갱신 실패: Refresh Token 해시 불일치', {
+          '유저 UUID': userInAccessToken.uuid,
+          이메일: userInAccessToken.email,
+          'DB에 토큰 존재 여부': !!user.hashedRefreshToken,
+        });
         return false;
       }
 
@@ -183,28 +162,22 @@ export class AuthService {
         !user.refreshTokenExpiresAt ||
         user.refreshTokenExpiresAt <= new Date()
       ) {
-        this.logger.warn(
-          [
-            '[토큰 갱신 실패: Refresh Token 만료]',
-            `- 유저 UUID: ${userInAccessToken.uuid}`,
-            `- 이메일: ${userInAccessToken.email}`,
-            `- 만료 시각: ${user.refreshTokenExpiresAt?.toISOString() ?? '(없음)'}`,
-          ].join('\n'),
-        );
+        this.logger.warn('토큰 갱신 실패: Refresh Token 만료', {
+          '유저 UUID': userInAccessToken.uuid,
+          이메일: userInAccessToken.email,
+          '만료 시각': user.refreshTokenExpiresAt?.toISOString(),
+        });
         return false;
       }
 
       return true;
     } catch (error) {
       // 토큰 검증 실패 (만료되었거나 서명이 잘못된 경우)
-      this.logger.warn(
-        [
-          '[토큰 갱신 실패: Refresh Token 서명 검증 실패]',
-          `- 유저 UUID: ${userInAccessToken.uuid}`,
-          `- 이메일: ${userInAccessToken.email}`,
-          `- 에러: ${error.message}`,
-        ].join('\n'),
-      );
+      this.logger.warn('토큰 갱신 실패: Refresh Token 서명 검증 실패', {
+        '유저 UUID': userInAccessToken.uuid,
+        이메일: userInAccessToken.email,
+        에러: error.message,
+      });
       return false;
     }
   }
@@ -226,9 +199,9 @@ export class AuthService {
         userType: payload.userType,
       };
     } catch (error) {
-      this.logger.warn(
-        ['[Access Token 디코딩 실패]', `- 에러: ${error.message}`].join('\n'),
-      );
+      this.logger.warn('Access Token 디코딩 실패', {
+        에러: error.message,
+      });
       return null;
     }
   }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -24,10 +24,9 @@ export class AuthService {
 
     if (!user) {
       this.logger.warn(
-        [
-          '[로그인 실패: 존재하지 않는 이메일]',
-          `- 시도 이메일: ${email}`,
-        ].join('\n'),
+        ['[로그인 실패: 존재하지 않는 이메일]', `- 시도 이메일: ${email}`].join(
+          '\n',
+        ),
       );
       return null;
     }
@@ -211,10 +210,7 @@ export class AuthService {
       };
     } catch (error) {
       this.logger.warn(
-        [
-          '[Access Token 디코딩 실패]',
-          `- 에러: ${error.message}`,
-        ].join('\n'),
+        ['[Access Token 디코딩 실패]', `- 에러: ${error.message}`].join('\n'),
       );
       return null;
     }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -133,6 +133,14 @@ export class AuthService {
 
       // 2. 리프레시 토큰의 payload가 액세스 토큰의 정보와 일치하는지 검증
       if (userInRefreshToken.uuid !== userInAccessToken.uuid) {
+        this.logger.warn(
+          [
+            '[토큰 갱신 실패: UUID 불일치]',
+            `- Access Token UUID: ${userInAccessToken.uuid}`,
+            `- Refresh Token UUID: ${userInRefreshToken.uuid}`,
+            `- 이메일: ${userInAccessToken.email}`,
+          ].join('\n'),
+        );
         return false;
       }
 
@@ -143,6 +151,14 @@ export class AuthService {
       const hashedToken = this.hashToken(refreshToken);
 
       if (!user.hashedRefreshToken || user.hashedRefreshToken !== hashedToken) {
+        this.logger.warn(
+          [
+            '[토큰 갱신 실패: Refresh Token 해시 불일치]',
+            `- 유저 UUID: ${userInAccessToken.uuid}`,
+            `- 이메일: ${userInAccessToken.email}`,
+            `- DB에 토큰 존재 여부: ${!!user.hashedRefreshToken}`,
+          ].join('\n'),
+        );
         return false;
       }
 
@@ -151,12 +167,28 @@ export class AuthService {
         !user.refreshTokenExpiresAt ||
         user.refreshTokenExpiresAt <= new Date()
       ) {
+        this.logger.warn(
+          [
+            '[토큰 갱신 실패: Refresh Token 만료]',
+            `- 유저 UUID: ${userInAccessToken.uuid}`,
+            `- 이메일: ${userInAccessToken.email}`,
+            `- 만료 시각: ${user.refreshTokenExpiresAt?.toISOString() ?? '(없음)'}`,
+          ].join('\n'),
+        );
         return false;
       }
 
       return true;
     } catch (error) {
       // 토큰 검증 실패 (만료되었거나 서명이 잘못된 경우)
+      this.logger.warn(
+        [
+          '[토큰 갱신 실패: Refresh Token 서명 검증 실패]',
+          `- 유저 UUID: ${userInAccessToken.uuid}`,
+          `- 이메일: ${userInAccessToken.email}`,
+          `- 에러: ${error.message}`,
+        ].join('\n'),
+      );
       return false;
     }
   }
@@ -178,6 +210,12 @@ export class AuthService {
         userType: payload.userType,
       };
     } catch (error) {
+      this.logger.warn(
+        [
+          '[Access Token 디코딩 실패]',
+          `- 에러: ${error.message}`,
+        ].join('\n'),
+      );
       return null;
     }
   }

--- a/src/auth/strategies/local.strategy.ts
+++ b/src/auth/strategies/local.strategy.ts
@@ -1,10 +1,12 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-local';
 import { AuthService } from '../auth.service';
 
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {
+  private readonly logger = new Logger(LocalStrategy.name);
+
   constructor(private readonly authService: AuthService) {
     super({ usernameField: 'email' });
   }
@@ -12,6 +14,12 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
   async validate(email: string, password: string): Promise<any> {
     const user = await this.authService.validateUser(email, password);
     if (!user) {
+      this.logger.warn(
+        [
+          '[인증 차단: 로그인 실패]',
+          `- 이메일: ${email}`,
+        ].join('\n'),
+      );
       throw new UnauthorizedException();
     }
     return user;

--- a/src/auth/strategies/local.strategy.ts
+++ b/src/auth/strategies/local.strategy.ts
@@ -15,10 +15,7 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
     const user = await this.authService.validateUser(email, password);
     if (!user) {
       this.logger.warn(
-        [
-          '[인증 차단: 로그인 실패]',
-          `- 이메일: ${email}`,
-        ].join('\n'),
+        ['[인증 차단: 로그인 실패]', `- 이메일: ${email}`].join('\n'),
       );
       throw new UnauthorizedException();
     }

--- a/src/auth/strategies/local.strategy.ts
+++ b/src/auth/strategies/local.strategy.ts
@@ -1,12 +1,10 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-local';
 import { AuthService } from '../auth.service';
 
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {
-  private readonly logger = new Logger(LocalStrategy.name);
-
   constructor(private readonly authService: AuthService) {
     super({ usernameField: 'email' });
   }
@@ -14,9 +12,6 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
   async validate(email: string, password: string): Promise<any> {
     const user = await this.authService.validateUser(email, password);
     if (!user) {
-      this.logger.warn(
-        ['[인증 차단: 로그인 실패]', `- 이메일: ${email}`].join('\n'),
-      );
       throw new UnauthorizedException();
     }
     return user;


### PR DESCRIPTION
## 요약
인증/쿠키 관련 흐름에서 보안 이벤트 추적 및 공격 탐지를 위한 구조화된 로깅을 추가합니다. 기존에는 로그인 실패, 토큰 갱신 실패, 비밀번호 변경 등 핵심 보안 이벤트에 대한 로깅이 전무했습니다.

## 작업 내용
### 변경 전
- 로그인 실패/토큰 검증 실패 시 로깅 없음 (무차별 대입 공격 탐지 불가)
- 회원가입에서 `console.log` 사용
- 비밀번호 초기화/변경 감사 추적 없음

### 변경 후
- `AuthService.validateUser`: 로그인 실패 3가지 경로 warn 로깅 (이메일 없음, 비활성 계정, 비밀번호 불일치)
- `AuthService.validateRefreshToken`: 토큰 검증 실패 4단계별 warn 로깅 (UUID 불일치, 해시 불일치, 만료, 서명 실패)
- `AuthService.decodeExpiredAccessToken`: 디코딩 실패 warn 로깅
- `AuthController.register`: `console.log` → NestJS `Logger`로 교체
- `AuthController.refresh`: 쿠키 누락/디코딩 실패/검증 실패/성공 로깅 (User-Agent 포함)
- `AuthController.resetPassword/updatePassword`: 비밀번호 초기화/변경 로깅
- `LocalStrategy`: Guard 레벨 인증 차단 로깅

### 로깅 정책
| 허용 | 금지 |
|---|---|
| 이메일, UUID, User-Agent, 계정 상태 | 이름, IP 주소, 비밀번호 |

### 로그 레벨
- `log`: 성공 이벤트 (회원가입, 토큰 갱신, 비밀번호 변경)
- `warn`: 인증 실패 이벤트
- `error`: 시스템 장애 (메일 전송 실패)

## 주의사항
- 기존 예약 감사 로그(`reserve.place.service.ts`)와 동일한 `[이벤트]\n- 키: 값` 포맷 사용
- 외부 로깅 라이브러리 추가 없이 NestJS 내장 `Logger`만 사용
- 동작 로직 변경 없음, 로깅만 추가

## 테스트
- [ ] `npm run build` 빌드 성공 확인
- [ ] 로그인 실패 시 warn 로그 출력 확인
- [ ] 토큰 갱신 실패 시 단계별 warn 로그 출력 확인
- [ ] 회원가입 시 log/error 로그 출력 확인