### PR TITLE
Fix/reservation-opening-hours

### DIFF
--- a/src/popo/reservation/equip/reserve.equip.controller.ts
+++ b/src/popo/reservation/equip/reserve.equip.controller.ts
@@ -235,6 +235,13 @@ export class ReserveEquipController {
 
     // When accepting, validate overlap against already accepted reservations
     if (status === ReservationStatus.accept) {
+      await this.reserveEquipService.assertReservationOpeningHours(
+        reservation.equipments,
+        reservation.date,
+        reservation.startTime,
+        reservation.endTime,
+      );
+
       const isOverlap = await this.reserveEquipService.isReservationOverlap(
         reservation.equipments,
         reservation.date,

--- a/src/popo/reservation/equip/reserve.equip.create.spec.ts
+++ b/src/popo/reservation/equip/reserve.equip.create.spec.ts
@@ -217,6 +217,134 @@ describe('ReserveEquip - Create (single equipment, overlap & midnight)', () => {
     });
   });
 
+  describe('openingHours policy', () => {
+    it('single equipment allows reservations inside opening hours', async () => {
+      const tmpEquip = await equipService.save({
+        name: 'Weekday Camera',
+        description: 'weekday camera',
+        equipOwner: EquipOwner.dongyeon,
+        staffEmail: 'staff@test.com',
+        maxMinutes: 180,
+        fee: 1000,
+        openingHours: '{"Monday":"09:00-18:00"}',
+      });
+
+      const res = await create({
+        equipments: [tmpEquip.uuid],
+        owner: EquipOwner.dongyeon,
+        phone: '010',
+        title: 'Inside',
+        description: 'Inside',
+        date: '20251222',
+        startTime: '1000',
+        endTime: '1100',
+      });
+
+      expect(res.status).toBe(ReservationStatus.in_process);
+    });
+
+    it('single equipment rejects reservations outside opening hours', async () => {
+      const tmpEquip = await equipService.save({
+        name: 'Closed Morning Camera',
+        description: 'closed camera',
+        equipOwner: EquipOwner.dongyeon,
+        staffEmail: 'staff@test.com',
+        maxMinutes: 180,
+        fee: 1000,
+        openingHours: '{"Monday":"09:00-18:00"}',
+      });
+
+      await expect(
+        create({
+          equipments: [tmpEquip.uuid],
+          owner: EquipOwner.dongyeon,
+          phone: '010',
+          title: 'Before',
+          description: 'Before',
+          date: '20251222',
+          startTime: '0830',
+          endTime: '0930',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('multi-equipment reservation fails if any selected equipment is unavailable', async () => {
+      const openEquip = await equipService.save({
+        name: 'Always Open Camera',
+        description: 'open camera',
+        equipOwner: EquipOwner.dongyeon,
+        staffEmail: 'staff@test.com',
+        maxMinutes: 180,
+        fee: 1000,
+        openingHours: '{"Everyday":"00:00-24:00"}',
+      });
+      const unavailableEquip = await equipService.save({
+        name: 'Afternoon Only Camera',
+        description: 'afternoon camera',
+        equipOwner: EquipOwner.dongyeon,
+        staffEmail: 'staff@test.com',
+        maxMinutes: 180,
+        fee: 1000,
+        openingHours: '{"Monday":"13:00-18:00"}',
+      });
+
+      await expect(
+        create({
+          equipments: [openEquip.uuid, unavailableEquip.uuid],
+          owner: EquipOwner.dongyeon,
+          phone: '010',
+          title: 'Mixed',
+          description: 'Mixed',
+          date: '20251222',
+          startTime: '1000',
+          endTime: '1100',
+        }),
+      ).rejects.toThrow('Afternoon Only Camera');
+    });
+
+    it('admin acceptance rejects a pending reservation when equipment opening hours no longer allow it', async () => {
+      const tmpEquip = await equipService.save({
+        name: 'Approval Camera',
+        description: 'approval camera',
+        equipOwner: EquipOwner.dongyeon,
+        staffEmail: 'staff@test.com',
+        maxMinutes: 180,
+        fee: 1000,
+        openingHours: '{"Everyday":"00:00-24:00"}',
+      });
+
+      const reservation = await create({
+        equipments: [tmpEquip.uuid],
+        owner: EquipOwner.dongyeon,
+        phone: '010',
+        title: 'Pending',
+        description: 'Pending',
+        date: '20251222',
+        startTime: '1000',
+        endTime: '1100',
+      });
+      expect(reservation.status).toBe(ReservationStatus.in_process);
+
+      await equipService.update(tmpEquip.uuid, {
+        name: tmpEquip.name,
+        description: tmpEquip.description,
+        fee: tmpEquip.fee,
+        equipOwner: tmpEquip.equipOwner,
+        staffEmail: tmpEquip.staffEmail,
+        maxMinutes: tmpEquip.maxMinutes,
+        openingHours: '{"Monday":"13:00-18:00"}',
+      });
+
+      await expect(
+        controller.patchStatus(
+          reservation.uuid,
+          ReservationStatus.accept,
+          false,
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
   describe('Admin acceptance (overlap vs non-overlap)', () => {
     it('Overlapping request should fail on admin accept', async () => {
       const a = await create({

--- a/src/popo/reservation/equip/reserve.equip.service.ts
+++ b/src/popo/reservation/equip/reserve.equip.service.ts
@@ -9,9 +9,11 @@ import { ReservationStatus } from '../reservation.meta';
 import { JwtPayload } from '../../../auth/strategies/jwt.payload';
 import {
   calculateReservationDurationMinutes,
+  isOnOpeningHours,
   timeStringToMinutes,
 } from '../../../utils/reservation-utils';
 import { UserType } from '../../user/user.meta';
+import { Equip } from '../../equip/equip.entity';
 
 const Message = {
   NOT_EXISTING_USER: "There's no such user.",
@@ -23,6 +25,7 @@ const Message = {
     'Your reservation is already exist on that day: accepted or in-progress.',
   OVER_MAX_RESERVATION_TIME:
     'Over the allocated reservation minutes of that day.',
+  NOT_ON_OPENING_HOURS: 'Reservation time is outside opening hours.',
 };
 
 @Injectable()
@@ -82,6 +85,13 @@ export class ReserveEquipService {
       throw new BadRequestException(Message.NOT_EXISTING_EQUIP);
     }
 
+    this.assertEquipmentsOnOpeningHours(
+      targetEquipments,
+      date,
+      startTime,
+      endTime,
+    );
+
     // Reservation Overlap Check
     const isReservationOverlap = await this.isReservationOverlap(
       equipments,
@@ -138,6 +148,43 @@ export class ReserveEquipService {
     }
 
     return this.reserveEquipRepo.save(dto);
+  }
+
+  async assertReservationOpeningHours(
+    equipmentIds: string[],
+    date: string,
+    startTime: string,
+    endTime: string,
+  ) {
+    const targetEquipments = await this.equipService.findByIds(equipmentIds);
+    this.assertEquipmentsOnOpeningHours(
+      targetEquipments,
+      date,
+      startTime,
+      endTime,
+    );
+  }
+
+  private assertEquipmentsOnOpeningHours(
+    equipments: Equip[],
+    date: string,
+    startTime: string,
+    endTime: string,
+  ) {
+    const unavailableEquipments = equipments.filter(
+      (equipment) =>
+        !isOnOpeningHours(equipment.openingHours, date, startTime, endTime),
+    );
+
+    if (unavailableEquipments.length) {
+      const unavailableEquipmentNames = unavailableEquipments
+        .map((equipment) => equipment.name)
+        .join(', ');
+
+      throw new BadRequestException(
+        `${Message.NOT_ON_OPENING_HOURS}: ${unavailableEquipmentNames} 장비는 ${date} ${startTime} ~ ${endTime}에 예약할 수 없습니다. 사용 가능 시간을 확인해주세요.`,
+      );
+    }
   }
 
   countEquipmentReservations(equipmentId: string) {

--- a/src/popo/reservation/place/reserve.place.create.spec.ts
+++ b/src/popo/reservation/place/reserve.place.create.spec.ts
@@ -221,6 +221,143 @@ describe('ReservePlace - Create (concurrency, policies, midnight)', () => {
     });
   });
 
+  describe('openingHours policy', () => {
+    it('Monday 09:00-18:00 place allows 10:00-11:00', async () => {
+      const place = await placeService.save({
+        name: 'Weekday Open Place',
+        description: 'desc',
+        location: 'loc',
+        region: PlaceRegion.student_hall,
+        staffEmail: 'staff@test.com',
+        maxMinutes: 180,
+        maxConcurrentReservation: 1,
+        openingHours: '{"Monday":"09:00-18:00"}',
+        enableAutoAccept: PlaceEnableAutoAccept.active,
+      });
+
+      const res = await create({
+        placeId: place.uuid,
+        phone: '010',
+        title: 'Inside',
+        description: 'Inside',
+        date: '20251222',
+        startTime: '1000',
+        endTime: '1100',
+      });
+
+      expect(res.status).toBe(ReservationStatus.accept);
+    });
+
+    it('Monday 09:00-18:00 place rejects times outside the opening range', async () => {
+      const place = await placeService.save({
+        name: 'Weekday Closed Place',
+        description: 'desc',
+        location: 'loc',
+        region: PlaceRegion.student_hall,
+        staffEmail: 'staff@test.com',
+        maxMinutes: 180,
+        maxConcurrentReservation: 1,
+        openingHours: '{"Monday":"09:00-18:00"}',
+        enableAutoAccept: PlaceEnableAutoAccept.active,
+      });
+
+      await expect(
+        create({
+          placeId: place.uuid,
+          phone: '010',
+          title: 'Before',
+          description: 'Before',
+          date: '20251222',
+          startTime: '0830',
+          endTime: '0930',
+        }),
+      ).rejects.toThrow();
+
+      await expect(
+        create({
+          placeId: place.uuid,
+          phone: '010',
+          title: 'After',
+          description: 'After',
+          date: '20251222',
+          startTime: '1800',
+          endTime: '1830',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('split opening ranges reject reservations crossing closed time', async () => {
+      const place = await placeService.save({
+        name: 'Split Hours Place',
+        description: 'desc',
+        location: 'loc',
+        region: PlaceRegion.student_hall,
+        staffEmail: 'staff@test.com',
+        maxMinutes: 360,
+        maxConcurrentReservation: 1,
+        openingHours: '{"Monday":"00:00-10:00 & 13:00-24:00"}',
+        enableAutoAccept: PlaceEnableAutoAccept.active,
+      });
+
+      await expect(
+        create({
+          placeId: place.uuid,
+          phone: '010',
+          title: 'Cross Closed',
+          description: 'Cross Closed',
+          date: '20251222',
+          startTime: '0930',
+          endTime: '1330',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('manual approval rejects a pending reservation when place opening hours no longer allow it', async () => {
+      const place = await placeService.save({
+        name: 'Manual Opening Hours Place',
+        description: 'desc',
+        location: 'loc',
+        region: PlaceRegion.student_hall,
+        staffEmail: 'staff@test.com',
+        maxMinutes: 180,
+        maxConcurrentReservation: 1,
+        openingHours: '{"Everyday":"00:00-24:00"}',
+        enableAutoAccept: PlaceEnableAutoAccept.inactive,
+      });
+
+      const reservation = await create({
+        placeId: place.uuid,
+        phone: '010',
+        title: 'Pending',
+        description: 'Pending',
+        date: '20251222',
+        startTime: '1000',
+        endTime: '1100',
+      });
+      expect(reservation.status).toBe(ReservationStatus.in_process);
+
+      await placeService.update(place.uuid, {
+        name: place.name,
+        description: place.description,
+        location: place.location,
+        region: place.region,
+        staffEmail: place.staffEmail,
+        maxMinutes: place.maxMinutes,
+        maxConcurrentReservation: place.maxConcurrentReservation,
+        openingHours: '{"Monday":"13:00-18:00"}',
+        enableAutoAccept: place.enableAutoAccept,
+      });
+
+      await expect(
+        reservePlaceController.patchStatus(
+          reservation.uuid,
+          ReservationStatus.accept,
+          'false',
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
   // ---- Rejected overlap cases ----
   describe('Rejected overlaps (auto-accept)', () => {
     it('Partial overlap (front): 10:00-11:00 blocks 09:30-10:30', async () => {

--- a/src/popo/reservation/place/reserve.place.integration.spec.ts
+++ b/src/popo/reservation/place/reserve.place.integration.spec.ts
@@ -134,7 +134,7 @@ describe('ReservePlaceModule - Integration Test', () => {
         staffEmail: 'staff@test.com',
         maxMinutes: 120,
         maxConcurrentReservation: 1,
-        openingHours: '{"Monday":"09:00-18:00"}',
+        openingHours: '{"Everyday":"00:00-24:00"}',
         enableAutoAccept: PlaceEnableAutoAccept.inactive,
       });
 
@@ -205,7 +205,7 @@ describe('ReservePlaceModule - Integration Test', () => {
         staffEmail: 'staff@test.com',
         maxMinutes: 120,
         maxConcurrentReservation: 1,
-        openingHours: '{"Monday":"09:00-18:00"}',
+        openingHours: '{"Everyday":"00:00-24:00"}',
         enableAutoAccept: PlaceEnableAutoAccept.inactive,
       });
 
@@ -306,7 +306,7 @@ describe('ReservePlaceModule - Integration Test', () => {
         staffEmail: 'staff@test.com',
         maxMinutes: 120,
         maxConcurrentReservation: 1,
-        openingHours: '{"Monday":"09:00-18:00"}',
+        openingHours: '{"Everyday":"00:00-24:00"}',
         enableAutoAccept: PlaceEnableAutoAccept.inactive,
       });
 
@@ -388,7 +388,7 @@ describe('ReservePlaceModule - Integration Test', () => {
         staffEmail: 'staff@test.com',
         maxMinutes: 120,
         maxConcurrentReservation: 1,
-        openingHours: '{"Monday":"09:00-18:00"}',
+        openingHours: '{"Everyday":"00:00-24:00"}',
         enableAutoAccept: PlaceEnableAutoAccept.inactive,
       });
 
@@ -441,7 +441,7 @@ describe('ReservePlaceModule - Integration Test', () => {
         staffEmail: 'staff@test.com',
         maxMinutes: 120,
         maxConcurrentReservation: 1,
-        openingHours: '{"Monday":"09:00-18:00"}',
+        openingHours: '{"Everyday":"00:00-24:00"}',
         enableAutoAccept: PlaceEnableAutoAccept.inactive,
       });
 
@@ -492,7 +492,7 @@ describe('ReservePlaceModule - Integration Test', () => {
         staffEmail: 'staff@test.com',
         maxMinutes: 120,
         maxConcurrentReservation: 1,
-        openingHours: '{"Monday":"09:00-18:00"}',
+        openingHours: '{"Everyday":"00:00-24:00"}',
         enableAutoAccept: PlaceEnableAutoAccept.inactive,
       });
 
@@ -553,7 +553,7 @@ describe('ReservePlaceModule - Integration Test', () => {
         staffEmail: 'staff@test.com',
         maxMinutes: 120,
         maxConcurrentReservation: 1,
-        openingHours: '{"Monday":"09:00-18:00"}',
+        openingHours: '{"Everyday":"00:00-24:00"}',
         enableAutoAccept: PlaceEnableAutoAccept.inactive,
       });
 
@@ -604,7 +604,7 @@ describe('ReservePlaceModule - Integration Test', () => {
         staffEmail: 'staff@test.com',
         maxMinutes: 120,
         maxConcurrentReservation: 1,
-        openingHours: '{"Monday":"09:00-18:00"}',
+        openingHours: '{"Everyday":"00:00-24:00"}',
         enableAutoAccept: PlaceEnableAutoAccept.inactive,
       });
     });
@@ -632,7 +632,7 @@ describe('ReservePlaceModule - Integration Test', () => {
         staffEmail: 'staff@test.com',
         maxMinutes: 120,
         maxConcurrentReservation: 1,
-        openingHours: '{"Monday":"09:00-18:00"}',
+        openingHours: '{"Everyday":"00:00-24:00"}',
         enableAutoAccept: PlaceEnableAutoAccept.inactive,
       });
 
@@ -712,7 +712,7 @@ describe('ReservePlaceModule - Integration Test', () => {
         staffEmail: 'staff@test.com',
         maxMinutes: 120,
         maxConcurrentReservation: 1,
-        openingHours: '{"Monday":"09:00-18:00"}',
+        openingHours: '{"Everyday":"00:00-24:00"}',
         enableAutoAccept: PlaceEnableAutoAccept.inactive,
       });
 
@@ -783,7 +783,7 @@ describe('ReservePlaceModule - Integration Test', () => {
         staffEmail: 'staff@test.com',
         maxMinutes: 120,
         maxConcurrentReservation: 1,
-        openingHours: '{"Monday":"09:00-18:00"}',
+        openingHours: '{"Everyday":"00:00-24:00"}',
         enableAutoAccept: PlaceEnableAutoAccept.inactive,
       });
 
@@ -889,7 +889,7 @@ describe('ReservePlaceModule - Integration Test', () => {
         staffEmail: 'staff@test.com',
         maxMinutes: 120,
         maxConcurrentReservation: 1,
-        openingHours: '{"Monday":"09:00-18:00"}',
+        openingHours: '{"Everyday":"00:00-24:00"}',
         enableAutoAccept: PlaceEnableAutoAccept.inactive,
       });
 

--- a/src/popo/reservation/place/reserve.place.service.ts
+++ b/src/popo/reservation/place/reserve.place.service.ts
@@ -10,6 +10,7 @@ import { PlaceEnableAutoAccept, PlaceRegion } from '../../place/place.meta';
 import { JwtPayload } from '../../../auth/strategies/jwt.payload';
 import {
   calculateReservationDurationMinutes,
+  isOnOpeningHours,
   timeStringToMinutes,
 } from '../../../utils/reservation-utils';
 import { UserType } from 'src/popo/user/user.meta';
@@ -22,6 +23,7 @@ const Message = {
   NOT_ENOUGH_INFORMATION: "There's no enough information about reservation",
   OVER_MAX_RESERVATION_TIME:
     'Over the allocated reservation minutes of that day.',
+  NOT_ON_OPENING_HOURS: 'Reservation time is outside opening hours.',
 };
 
 @Injectable()
@@ -101,6 +103,12 @@ export class ReservePlaceService {
     }
 
     const targetPlace = await this.placeService.findOneByUuidOrFail(placeId);
+
+    if (!isOnOpeningHours(targetPlace.openingHours, date, startTime, endTime)) {
+      throw new BadRequestException(
+        `${Message.NOT_ON_OPENING_HOURS}: "${targetPlace.name}" 장소는 ${date} ${startTime} ~ ${endTime}에 예약할 수 없습니다. 사용 가능 시간을 확인해주세요.`,
+      );
+    }
 
     // Reservation Concurrent Check
     const isConcurrentPossible = await this.isReservationConcurrent(

--- a/src/utils/reservation-utils.spec.ts
+++ b/src/utils/reservation-utils.spec.ts
@@ -1,0 +1,60 @@
+import { isOnOpeningHours } from './reservation-utils';
+
+describe('reservation-utils opening hours', () => {
+  it('allows reservations inside Everyday 24-hour opening hours', () => {
+    expect(
+      isOnOpeningHours(
+        '{"Everyday":"00:00-24:00"}',
+        '20251222',
+        '2300',
+        '0000',
+      ),
+    ).toBe(true);
+  });
+
+  it('allows weekday reservations inside a single opening range', () => {
+    expect(
+      isOnOpeningHours('{"Monday":"09:00-18:00"}', '20251222', '1000', '1100'),
+    ).toBe(true);
+  });
+
+  it('rejects reservations outside or crossing a weekday opening range', () => {
+    const openingHours = '{"Monday":"09:00-18:00"}';
+
+    expect(isOnOpeningHours(openingHours, '20251222', '0830', '0930')).toBe(
+      false,
+    );
+    expect(isOnOpeningHours(openingHours, '20251222', '1800', '1830')).toBe(
+      false,
+    );
+  });
+
+  it('supports split opening ranges and rejects reservations crossing closed time', () => {
+    const openingHours = '{"Monday":"00:00-10:00 & 13:00-24:00"}';
+
+    expect(isOnOpeningHours(openingHours, '20251222', '0900', '1000')).toBe(
+      true,
+    );
+    expect(isOnOpeningHours(openingHours, '20251222', '0930', '1330')).toBe(
+      false,
+    );
+  });
+
+  it('supports comma-separated opening ranges', () => {
+    expect(
+      isOnOpeningHours(
+        '{"Monday":"09:00-12:00, 13:00-18:00"}',
+        '20251222',
+        '1330',
+        '1430',
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects missing weekday rules and invalid JSON', () => {
+    expect(
+      isOnOpeningHours('{"Tuesday":"09:00-18:00"}', '20251222', '1000', '1100'),
+    ).toBe(false);
+    expect(isOnOpeningHours('invalid', '20251222', '1000', '1100')).toBe(false);
+  });
+});

--- a/src/utils/reservation-utils.ts
+++ b/src/utils/reservation-utils.ts
@@ -22,3 +22,129 @@ export function calculateReservationDurationMinutes(
   const duration = end - start;
   return duration >= 0 ? duration : 0;
 }
+
+const WEEKDAYS = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+] as const;
+
+function getWeekdayFromDate(date: string): (typeof WEEKDAYS)[number] | null {
+  if (!/^\d{8}$/.test(date)) {
+    return null;
+  }
+
+  const year = Number(date.slice(0, 4));
+  const month = Number(date.slice(4, 6));
+  const day = Number(date.slice(6, 8));
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return WEEKDAYS[parsed.getUTCDay()];
+}
+
+function openingTimeToMinutes(time: string): number | null {
+  const match = time.trim().match(/^(\d{2}):(\d{2})$/);
+  if (!match) {
+    return null;
+  }
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+
+  if (hours === 24 && minutes === 0) {
+    return 24 * 60;
+  }
+
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+    return null;
+  }
+
+  return hours * 60 + minutes;
+}
+
+function getOpeningRangesMinutes(
+  openingHours: string,
+  date: string,
+): Array<[number, number]> | null {
+  let parsed: Record<string, string>;
+  try {
+    parsed = JSON.parse(openingHours);
+  } catch {
+    return null;
+  }
+
+  const weekday = getWeekdayFromDate(date);
+  if (!weekday) {
+    return null;
+  }
+
+  const targetOpeningHours = parsed.Everyday ?? parsed[weekday];
+  if (typeof targetOpeningHours !== 'string' || !targetOpeningHours.trim()) {
+    return null;
+  }
+
+  const ranges: Array<[number, number]> = [];
+  const rangeTexts = targetOpeningHours
+    .split(',')
+    .flatMap((rangeText) => rangeText.split('&'));
+
+  for (const rangeText of rangeTexts) {
+    const [startText, endText, ...rest] = rangeText
+      .trim()
+      .split('-')
+      .map((text) => text.trim());
+
+    if (!startText || !endText || rest.length > 0) {
+      return null;
+    }
+
+    const openStart = openingTimeToMinutes(startText);
+    const openEnd = openingTimeToMinutes(endText);
+    if (openStart === null || openEnd === null || openStart >= openEnd) {
+      return null;
+    }
+
+    ranges.push([openStart, openEnd]);
+  }
+
+  return ranges.length ? ranges : null;
+}
+
+export function isOnOpeningHours(
+  openingHours: string,
+  date: string,
+  startTime: string,
+  endTime: string,
+): boolean {
+  const reservationStart = timeStringToMinutes(startTime, false);
+  const reservationEnd = timeStringToMinutes(endTime, true);
+  if (
+    !Number.isFinite(reservationStart) ||
+    !Number.isFinite(reservationEnd) ||
+    reservationStart >= reservationEnd
+  ) {
+    return false;
+  }
+
+  const openingRanges = getOpeningRangesMinutes(openingHours, date);
+  if (!openingRanges) {
+    return false;
+  }
+
+  return openingRanges.some(
+    ([openStart, openEnd]) =>
+      openStart <= reservationStart && reservationEnd <= openEnd,
+  );
+}


### PR DESCRIPTION
## 요약
장소/장비 예약 API에서 사용 가능 시간(`openingHours`) 검증을 서버에도 추가합니다. 기존에는 프론트엔드에서만 사용 가능 시간을 막고 있어, API를 직접 호출하거나 우회하면 장소/장비의 예약 가능 시간이 아님에도 예약 생성 또는 승인이 가능했습니다.

## 작업 내용
### 변경 전
- 장소/장비 `openingHours` 검증이 프론트엔드에만 존재
- `POST /reservation-place`, `POST /reservation-place/check_possible`, 장소 예약 승인 경로에서 사용 가능 시간 외 예약을 서버에서 차단하지 않음
- `POST /reservation-equip`, 장비 예약 승인 경로에서 선택 장비별 사용 가능 시간 검증 없음
- 잘못된 `openingHours` JSON 또는 누락된 요일 규칙에 대한 서버 방어 없음

### 변경 후
- `reservation-utils`: `isOnOpeningHours` 공통 검증 유틸 추가
- `ReservePlaceService.checkReservationPossible`: 장소 예약 생성/가능 여부 확인/승인 전 `openingHours` 검증 추가
- `ReserveEquipService.save`: 선택된 모든 장비의 `openingHours` 검증 추가
- `ReserveEquipController.patchStatus`: 장비 예약 `accept` 처리 전 `openingHours` 재검증 추가
- `ReserveEquipService.assertReservationOpeningHours/assertEquipmentsOnOpeningHours`: 실패 시 `BadRequestException`을 던지는 검증 메서드로 정리
- 사용 불가 시간대 요청 시 장소명 또는 사용 불가 장비명을 포함한 400 응답 반환

### 검증 정책
| 허용 | 금지 |
|---|---|
| 예약 구간 전체가 하나의 오픈 구간 안에 포함되는 경우 | 오픈 구간 밖, 닫힌 시간을 걸치는 예약, 누락 요일, 잘못된 JSON/range |

### 시간표 처리
- `Everyday` 규칙이 있으면 우선 적용
- 없으면 예약 날짜(`YYYYMMDD`)의 요일(`Monday`~`Sunday`) 규칙 적용
- `09:00-18:00`, `00:00-10:00 & 13:00-24:00`, comma로 나뉜 복수 구간 지원
- 예약 종료 시간 `0000`은 기존 예약 로직과 동일하게 `24:00`으로 처리
- 잘못된 `openingHours` 설정은 안전하게 예약 불가로 처리

## 주의사항
- DB 마이그레이션 없음
- 외부 라이브러리 추가 없음
- 프론트엔드의 기존 사용 가능 시간 검증 정책과 동일하게 “예약 전체 구간이 하나의 오픈 구간 안에 포함”될 때만 허용
- 장소와 장비 모두 서버에서 검증하므로 API 직접 호출/우회 예약도 차단됨

## 테스트
- [x] `npm test -- reservation-utils.spec.ts reserve.place.create.spec.ts reserve.equip.create.spec.ts`
- [x] `pre-commit run --all-files`
- [x] 커밋 시 pre-commit hook 통과